### PR TITLE
fix(mushroom): split compartments by dopamine input, not MBON feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,15 +214,20 @@ potentiation here, only depression with a floor and a slow drift back toward
 baseline standing in for forgetting.
 
 Which MBONs count as reward-side and which as punishment-side is **not
-hardcoded from a table**. For each MBON, total PAM input weight is compared
-against total PPL1 input and the stronger wins. That split puts MBON01, 02 and
-03 on the reward side and MBON04, 10 and 11 on the punishment side, which is
-where the literature puts them — a good sign it is finding real structure
-rather than noise.
+hardcoded from a table**. For each MBON, total PAM-to-MBON synapse count is
+compared against total PPL1-to-MBON count and the larger wins; ties are
+unassigned. These are anatomical counts from pairs with at least three
+synapses, stored separately because dopamine has zero fast weight. The male
+graph gives 39 reward-side MBONs, 56 punishment-side and 2 unassigned. The
+literature split holds only partly: MBON01, 02 and 03 are reward-side and
+MBON11 is punishment-side, but both MBON04 neurons are reward-side, and
+MBON10 has eight reward-side neurons and one punishment-side neuron.
 
 ```
-44,042 KC->MBON synapses     27,939 reward-side     14,349 punish-side
+44,042 KC->MBON weight positions     22,702 reward-side     20,044 punish-side     1,296 unassigned
 ```
+
+These positions count connected neuron pairs, not individual synapses.
 
 Measured, with controls — twenty rewarded encounters with one view:
 
@@ -231,6 +236,9 @@ Measured, with controls — twenty rewarded encounters with one view:
 | reward-side MBONs | **−6.0%** | depressed, it was the addressed compartment |
 | punishment-side MBONs | −0.9% | ~0, never addressed |
 | Kenyon cells | +0.3% | ~0, upstream of the synapse that changed |
+
+These numbers were measured under the MBON-to-dopamine feedback split and
+should be re-run under the anatomical input split; they have not been re-run.
 
 **The reward signal is not real, and the module says so in as many words.** A
 fly is rewarded by sugar, not by reaching a web page. Novelty stands in for it

--- a/build_graph.py
+++ b/build_graph.py
@@ -8,6 +8,7 @@ Inputs (CC-BY, storage.googleapis.com/flyem-male-cns):
 
 Output:
   build/graph.npz   W (CSR, mV per presynaptic spike), body index, sign, type codes
+                    and anatomical PAM/PPL1 -> MBON synapse counts
 
 Sign convention follows Shiu et al. 2024 (Nature): acetylcholine excitatory,
 GABA and glutamate inhibitory. Monoamines are modulatory in reality; they are
@@ -96,6 +97,11 @@ def main():
     print("building sparse matrix ...")
     r = idx.loc[post_a].to_numpy()   # row = postsynaptic
     c = idx.loc[pre_a].to_numpy()    # col = presynaptic
+    # Retain anatomical dopamine inputs separately from zero fast weights.
+    is_dop = np.char.startswith(types, "PAM") | np.char.startswith(types, "PPL1")
+    is_mbon = np.char.startswith(types, "MBON")
+    dop = is_dop[c] & is_mbon[r]
+    dop_pre, dop_post, dop_count = c[dop], r[dop], wt_a[dop]
     v = wt_a * MV_PER_SYNAPSE * sign[c]
 
     keep = v != 0.0
@@ -114,6 +120,7 @@ def main():
         data=W.data, indices=W.indices, indptr=W.indptr, shape=W.shape,
         bodies=bodies, sign=sign, types=types, superclass=superclass,
         subclass=subclass, receptor=receptor, fru=fru, nt=nt_str,
+        dop_pre=dop_pre, dop_post=dop_post, dop_count=dop_count,
     )
     print(f"wrote {BUILD / 'graph.npz'}")
 

--- a/flysim.py
+++ b/flysim.py
@@ -51,6 +51,11 @@ class FlyBrain:
         self.receptor = z["receptor"].astype(str)
         self.fru = z["fru"].astype(str)
         self.nt = z["nt"].astype(str)
+        self.dop_inputs = (
+            tuple(z[key] for key in ("dop_pre", "dop_post", "dop_count"))
+            if all(key in z for key in ("dop_pre", "dop_post", "dop_count"))
+            else None
+        )
         self.p = p
 
         # cell-type codes, for per-type trainable gains

--- a/mushroom.py
+++ b/mushroom.py
@@ -16,11 +16,14 @@ forgetting.
 
 Which MBONs count as reward-side and which as punishment-side is not
 hardcoded from a table. It is read out of this connectome: for each MBON,
-total PAM input weight is compared against total PPL1 input weight and the
-stronger one wins. That split puts MBON01, 02 and 03 on the reward side and
-MBON04, 10 and 11 on the punishment side, which is where the literature puts
-them - a reassuring sign the split is finding real structure rather than
-noise.
+total PAM-to-MBON synapse count is compared against total PPL1-to-MBON count
+and the larger one wins; ties are unassigned. These are anatomical counts
+from pairs with at least three synapses, stored separately because dopamine
+has zero fast weight. The male graph gives 39 reward-side MBONs, 56
+punishment-side and 2 unassigned. The literature split holds only partly:
+MBON01, 02 and 03 are reward-side and MBON11 is punishment-side, but both
+MBON04 neurons are reward-side, and MBON10 has eight reward-side neurons
+and one punishment-side neuron.
 
 What is honest about this and what is not:
 
@@ -28,10 +31,9 @@ What is honest about this and what is not:
 * The reward signal is not. A fly is rewarded by sugar, not by reaching a web
   page. Novelty stands in for it here, which is a modelling choice made by a
   person, and the fly has no say in it.
-* The compartments are lopsided in this data - 27,939 KC-to-MBON synapses
-  sit on the reward side against 14,349 on the punishment side - so
-  punishment has about half as much to work with as reward does. That
-  asymmetry is in the measurement, not in the code.
+* Of the 44,042 KC-to-MBON weight positions in the male graph, 22,702 sit on
+  the reward side, 20,044 on the punishment side and 1,296 are unassigned.
+  These positions count connected neuron pairs, not individual synapses.
 """
 import os
 import re
@@ -63,9 +65,17 @@ class MushroomBody:
         self.mbon = sel(r"^MBON")
         pam, ppl1 = sel(r"^PAM"), sel(r"^PPL1")
 
-        W = fb.W                      # CSC: column j = targets of presynaptic j
-        pam_in = np.abs(np.asarray(W[pam][:, self.mbon].sum(axis=0)).ravel())
-        ppl_in = np.abs(np.asarray(W[ppl1][:, self.mbon].sum(axis=0)).ravel())
+        pam_in = np.zeros(len(self.mbon))
+        ppl_in = np.zeros(len(self.mbon))
+        if fb.dop_inputs is None:
+            print("Graph predates the anatomical split and should be rebuilt.")
+        else:
+            dop_pre, dop_post, dop_count = fb.dop_inputs
+            for group, total in ((pam, pam_in), (ppl1, ppl_in)):
+                hit = np.isin(dop_pre, group)
+                total[:] = np.bincount(
+                    dop_post[hit], weights=dop_count[hit], minlength=fb.n
+                )[self.mbon]
         self.reward_side = self.mbon[pam_in > ppl_in]
         self.punish_side = self.mbon[ppl_in > pam_in]
 


### PR DESCRIPTION
## What was wrong

`MushroomBody.__init__` decides which MBONs are reward-side and which are punishment-side by comparing PAM input against PPL1 input. It did that with

    pam_in = W[pam][:, self.mbon].sum(axis=0)

In this CSC layout `W[i, j]` is the weight from presynaptic `j` onto postsynaptic `i` (the same convention the KC loop right below relies on), so `W[pam][:, mbon]` is the weight from **MBON onto PAM**: feedback, not dopamine input. The split, and the README sentence about it matching the literature, were computed from the wrong direction of the matrix.

Flipping the selection finds nothing, because `build_graph.py` gives dopaminergic presynaptic neurons a fast weight of 0 (`SIGN["dopamine"] = 0.0`) and drops zero weights. The anatomical fact the docstring promises is not in the weighted graph at all.

## What this does

- `build_graph.py` keeps the raw PAM/PPL1 -> MBON synapse counts (pairs with >= 3 synapses, same filter as everything else) as three small arrays in `graph.npz`: `dop_pre`, `dop_post`, `dop_count`. Every existing key is unchanged; the rebuild prints the same 165,122 neurons and 10,228,000 edges.
- `flysim.FlyBrain` exposes them as `dop_inputs` (None on an older graph).
- `mushroom.py` computes the split from those counts. An older graph gets no split and one printed line saying to rebuild.
- Docstring and README state what the male graph actually gives.

## Measured, male graph

PAM -> MBON: 27,090 synapses across 1,558 pairs. PPL1 -> MBON: 10,819 across 250.

| | old (feedback) | new (dopamine input) |
|---|---:|---:|
| reward-side MBONs | 45 | 39 |
| punishment-side MBONs | 47 | 56 |
| unassigned | 5 | 2 |
| KC->MBON positions reward / punish / none | 27,939 / 14,349 / 1,754 | 22,702 / 20,044 / 1,296 |

The literature split named in the docstring holds only partly under the real inputs: MBON01, 02 and 03 are reward-side and MBON11 is punishment-side, as before, but both MBON04 neurons land on the reward side (1,691 PAM vs 265 PPL1 synapses) and eight of the nine MBON10 neurons do too. The full per-type table is in the commit.

The "measured, with controls" table in the README was produced under the old split. I left its numbers and added one sentence saying so; they should be re-run under this split, which I have not done.

Found while building the female FlyWire fork (https://github.com/opifor/flybrain-female), where the same constructor runs on a second connectome. She launched her own token tonight through the same rig.
